### PR TITLE
fix(Baseline): problem when installing Pharo-Tree-Sitter

### DIFF
--- a/BaselineOfFASTTypeScript/BaselineOfFASTTypeScript.class.st
+++ b/BaselineOfFASTTypeScript/BaselineOfFASTTypeScript.class.st
@@ -47,7 +47,7 @@ BaselineOfFASTTypeScript >> defineDependencies: spec [
 	
 	spec baseline: 'TreeSitter' with: [ 
 		spec
-			loads: #( 'default' );
+			loads: #( 'moose' );
 			repository: 'github://Evref-BL/Pharo-Tree-Sitter:main/src' ].
 		
 	


### PR DESCRIPTION
Install Pharo-Tree-Sitter using the `moose` group instead of `default`, as the `moose` group includes the `TreeSitter-FAST-Utils` package required by the parser.